### PR TITLE
normalized author name initials

### DIFF
--- a/data_science_pipeline/utils/europepmc.py
+++ b/data_science_pipeline/utils/europepmc.py
@@ -1,3 +1,4 @@
+import re
 import logging
 from itertools import islice
 from typing import Callable, Iterable, List
@@ -21,11 +22,16 @@ EUROPEPMC_MAX_PAGE_SIZE = 1000
 EUROPEPMC_START_CURSOR = '*'
 
 
+def normalize_author_initials(author_name: str) -> str:
+    return re.sub(r'([A-Z])(\s)([A-Z])', r'\1\3', author_name, re.DOTALL)
+
+
 def get_europepmc_author_query_string(author_names: List[str]) -> str:
     if not author_names:
         raise ValueError('author names required')
     return '(%s) AND (SRC:"MED")' % ' OR '.join([
-        'AUTH:"%s"' % author for author in author_names
+        'AUTH:"%s"' % normalize_author_initials(author)
+        for author in author_names
     ])
 
 

--- a/tests/utils/europepmc_test.py
+++ b/tests/utils/europepmc_test.py
@@ -3,8 +3,23 @@ import pytest
 from data_science_pipeline.utils.europepmc import (
     get_europepmc_author_query_string,
     get_europepmc_pmid_query_string,
-    get_pmids_from_json_response
+    get_pmids_from_json_response,
+    normalize_author_initials
 )
+
+
+class TestNormalizeAuthorInitials:
+    def test_should_return_author_name_with_full_name(self):
+        assert normalize_author_initials('Smith John') == 'Smith John'
+
+    def test_should_return_author_name_with_simple_initial(self):
+        assert normalize_author_initials('Smith J') == 'Smith J'
+
+    def test_should_return_author_name_with_two_initials(self):
+        assert normalize_author_initials('Smith JX') == 'Smith JX'
+
+    def test_should_return_remove_space_between_initials(self):
+        assert normalize_author_initials('Smith J X') == 'Smith JX'
 
 
 class TestGetEuropepmcAuthorQueryString:
@@ -16,6 +31,11 @@ class TestGetEuropepmcAuthorQueryString:
         assert get_europepmc_author_query_string(
             ['Smith J']
         ) == '(AUTH:"Smith J") AND (SRC:"MED")'
+
+    def test_should_normalize_initials(self):
+        assert get_europepmc_author_query_string(
+            ['Smith J X']
+        ) == '(AUTH:"Smith JX") AND (SRC:"MED")'
 
 
 class TestGetEuropepmcPmidQueryString:


### PR DESCRIPTION
part of https://github.com/elifesciences/issues/issues/5735

This converts the search for `Sears K E` to `Sears KE`. So that EuropePMC returns the same results.