### PR TITLE
pin cloudpickle library to avoid ValueError: Cell is empty error

### DIFF
--- a/requirements.notebook.txt
+++ b/requirements.notebook.txt
@@ -1,6 +1,7 @@
 beautifulsoup4==4.9.1
 bigquery-schema-generator==1.0
 boto3==1.14.15
+cloudpickle==1.4.1
 ipywidgets==7.5.1
 joblib==0.16.0
 lxml==4.5.1


### PR DESCRIPTION
This seems to resolve the following error:

```text
distributed.protocol.pickle - INFO - Failed to serialize <function DaskExecutor.execute_async.<locals>.airflow_run at 0x7fa63c1c5b90>. Exception: Cell is empty
...
File "/usr/local/lib/python3.7/site-packages/dill/_dill.py", line 1146, in save_cell f = obj.cell_contents ValueError: Cell is empty
```

[git commit changes between 1.4.1 and 1.5.0](https://github.com/cloudpipe/cloudpickle/compare/v1.4.1...v1.5.0)