### PR TITLE
fixed isna check failing with lists

### DIFF
--- a/data_science_pipeline/utils/json.py
+++ b/data_science_pipeline/utils/json.py
@@ -5,8 +5,13 @@ from tempfile import TemporaryDirectory
 from typing import ContextManager, Iterable
 
 import pandas as pd
+import numpy as np
 
 from data_science_pipeline.utils.io import open_with_auto_compression
+
+
+def is_scalar_nan(value) -> bool:
+    return np.isscalar(value) and pd.isnull(value)
 
 
 # copied from:
@@ -15,7 +20,7 @@ def remove_key_with_null_value(record):
     if isinstance(record, dict):
         for key in list(record):
             val = record.get(key)
-            if pd.isna(val) or not val and not isinstance(val, bool):
+            if is_scalar_nan(val) or not val and not isinstance(val, bool):
                 record.pop(key, None)
             elif isinstance(val, (dict, list)):
                 remove_key_with_null_value(val)

--- a/tests/utils/bq_test.py
+++ b/tests/utils/bq_test.py
@@ -41,6 +41,16 @@ class TestDfAsJsonlFileWithoutNull:
             ]
         assert result == [{'parent': {'key1': 'value1'}}]
 
+    def test_should_not_fail_with_list_values_field(self, temp_dir: Path):
+        jsonl_file = temp_dir / 'data.jsonl'
+        df = pd.DataFrame([{'key1': ['value1', 'value2'], 'key2': None}])
+        with df_as_jsonl_file_without_null(df, gzip_enabled=False) as jsonl_file:
+            result = [
+                json.loads(line)
+                for line in Path(jsonl_file).read_text().splitlines()
+            ]
+        assert result == [{'key1': ['value1', 'value2']}]
+
     def test_should_use_gzip_compression_by_default(self, temp_dir: Path):
         jsonl_file = temp_dir / 'data.jsonl'
         df = pd.DataFrame([{'key1': 'value1', 'key2': None}])


### PR DESCRIPTION
failing to update the recommendations

```text
---------------------------------------------------------------------------
Exception encountered at "In [24]":
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
<ipython-input-24-61023f13f8e8> in <module>
      4     recommendation_output_table_name,
      5     project_id=project_id,
----> 6     if_exists='replace'
      7 )
      8 print('done')

~/git_repos/data_science_dags/data_science_pipeline/utils/bq.py in to_gbq(df, destination_table, if_exists, project_id, jsonl_file)
    206     """Similar to DataFrame.to_gpq but better handles schema detection of nested fields"""
    207     dataset_name, table_name = destination_table.split('.', maxsplit=1)
--> 208     with df_as_jsonl_file_without_null(df, jsonl_file=jsonl_file) as _jsonl_file:
    209         load_file_into_bq_with_auto_schema(
    210             _jsonl_file,

/usr/local/lib/python3.7/contextlib.py in __enter__(self)
    110         del self.args, self.kwds, self.func
    111         try:
--> 112             return next(self.gen)
    113         except StopIteration:
    114             raise RuntimeError("generator didn't yield") from None

~/git_repos/data_science_dags/data_science_pipeline/utils/bq.py in df_as_jsonl_file_without_null(df, **kwargs)
    193 @contextmanager
    194 def df_as_jsonl_file_without_null(df: pd.DataFrame, **kwargs) -> ContextManager[str]:
--> 195     json_list = remove_key_with_null_value(df.to_dict(orient='records'))
    196     with json_list_as_jsonl_file(json_list, **kwargs) as jsonl_file:
    197         yield jsonl_file

~/git_repos/data_science_dags/data_science_pipeline/utils/json.py in remove_key_with_null_value(record)
     24         for val in record:
     25             if isinstance(val, (dict, list)):
---> 26                 remove_key_with_null_value(val)
     27 
     28     return record

~/git_repos/data_science_dags/data_science_pipeline/utils/json.py in remove_key_with_null_value(record)
     16         for key in list(record):
     17             val = record.get(key)
---> 18             if pd.isna(val) or not val and not isinstance(val, bool):
     19                 record.pop(key, None)
     20             elif isinstance(val, (dict, list)):

ValueError: The truth value of an array with more than one element is ambiguous. Use a.any() or a.all()
```