### PR TITLE
downgraded cattrs to 1.0.0

### DIFF
--- a/requirements.notebook.txt
+++ b/requirements.notebook.txt
@@ -1,6 +1,7 @@
 beautifulsoup4==4.9.3
 bigquery-schema-generator==1.1
 boto3==1.16.12
+cattrs==1.0.0
 cloudpickle==1.4.1
 fbprophet==0.7.1
 ipywidgets==7.5.1


### PR DESCRIPTION
see https://github.com/elifesciences/data-hub-core-airflow-dags/pull/238

this has now caused other PRs to fail