### PR TITLE
Revert "build(deps): Bump google-cloud-bigquery from 2.3.1 to 2.4.0

### DIFF
--- a/requirements.notebook.txt
+++ b/requirements.notebook.txt
@@ -14,7 +14,7 @@ pandas-gbq==0.14.1
 pyarrow==2.0.0
 PyICU==2.6
 tqdm==4.52.0
-google-cloud-bigquery==2.4.0
+google-cloud-bigquery==2.3.1
 s3path==0.2.202
 scikit-learn==0.23.2
 six==1.15.0


### PR DESCRIPTION
This reverts commit 9f0836169c4cf9c7cbc5edf2f8aef37f532354fe.

This caused it to hang trying to read data from BigQuery via pandas-gbq.
(e.g. in the `peerscout-build-reviewing-editor-profiles` notebook)