### PR TITLE
fixed peerscout disambiguate missing project id

### DIFF
--- a/notebooks/peerscout/peerscout-disambiguate-editor-papers.ipynb
+++ b/notebooks/peerscout/peerscout-disambiguate-editor-papers.ipynb
@@ -26,6 +26,7 @@
    "source": [
     "import logging\n",
     "import sys\n",
+    "from functools import partial\n",
     "\n",
     "import pandas as pd\n",
     "\n",
@@ -34,7 +35,11 @@
     "\n",
     "from data_science_pipeline.sql import get_sql\n",
     "from data_science_pipeline.utils.bq import run_query_and_save_to_table, get_client\n",
-    "from data_science_pipeline.utils.jupyter import printmd, to_markdown_sql, read_big_query"
+    "from data_science_pipeline.utils.jupyter import (\n",
+    "    printmd,\n",
+    "    to_markdown_sql,\n",
+    "    read_big_query as _read_big_query\n",
+    ")"
    ]
   },
   {
@@ -54,6 +59,15 @@
    "outputs": [],
    "source": [
     "logging.basicConfig(level='INFO', stream=sys.stdout)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "read_big_query = partial(_read_big_query, project_id=project_id)"
    ]
   },
   {


### PR DESCRIPTION
When running the local Airflow pipeline, the `Data_Science_PeerScout_Get_Editor_Pubmed_Papers` would fail with the last step, due to no `project_id` being passed in to `read_big_query`.

This changes the corresponding notebook to pass in the `project_id` like it is done in other notebooks.