### PR TITLE
timezone issue with pd df

### DIFF
--- a/notebooks/peerscout/peerscout-get-editor-pubmed-paper-ids.ipynb
+++ b/notebooks/peerscout/peerscout-get-editor-pubmed-paper-ids.ipynb
@@ -225,7 +225,7 @@
    "source": [
     "editors_with_not_currently_updated_info_df = merged_editor_parsed_pubmed_links_df[\n",
     "    (\n",
-    "        pd.Timestamp.now()\n",
+    "        pd.to_datetime(pd.Timestamp.utcnow())\n",
     "        -\n",
     "        pd.to_datetime(merged_editor_parsed_pubmed_links_df['imported_timestamp'])\n",
     "    ).dt.days > 15\n",


### PR DESCRIPTION
```
TypeError: Timestamp subtraction must have the same timezones or no timezones

[2021-09-21 12:25:20,203] {taskinstance.py:1194} INFO - Marking task as UP_FOR_RETRY. dag_id=Data_Science_PeerScout_Get_Editor_Pubmed_Papers, task_id=peerscout_get_editor_pubmed_paper_ids, execution_date=20210921T110000, start_date=20210921T122512, end_date=20210921T122520
[2021-09-21 12:25:22,445] {local_task_job.py:102} INFO - Task exited with return code 1

```