### PR TITLE
increased ingress timeout for PeerScout API

### DIFF
--- a/charts/peerscout/values.yaml
+++ b/charts/peerscout/values.yaml
@@ -43,8 +43,8 @@ service:
 ingress:
   enabled: false
   annotations:
-    nginx.ingress.kubernetes.io/proxy-send-timeout: "90"
-    nginx.ingress.kubernetes.io/proxy-read-timeout: "90"
+    nginx.ingress.kubernetes.io/proxy-send-timeout: "180"
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "180"
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
   hosts:


### PR DESCRIPTION
error from loggly: `return super(_AsyncJob, self).result(timeout=timeout, **kwargs)`