### PR TITLE
Make queue of `Data_Science_PeerScout_Recommend_Reviewing_Editors` DAG configurable via env variable 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -250,7 +250,7 @@ airflow-logs:
 
 
 airflow-start:
-	$(AIRFLOW_DOCKER_COMPOSE) up worker webserver flower
+	$(AIRFLOW_DOCKER_COMPOSE) up worker webserver
 	$(MAKE) airflow-print-url
 
 

--- a/dags/peerscout_recommend_reviewing_editors.py
+++ b/dags/peerscout_recommend_reviewing_editors.py
@@ -2,6 +2,8 @@ import os
 
 # Note: DagBag.process_file skips files without "airflow" or "DAG" in them
 
+from airflow.models.baseoperator import DEFAULT_QUEUE
+
 from data_science_pipeline.utils.dags import (
     create_dag,
     create_run_notebook_operator
@@ -12,6 +14,10 @@ DEFAULT_PEERSCOUT_RECOMMEND_SCHEDULE = '@hourly'
 
 DATA_SCIENCE_PEERSCOUT_RECOMMEND_SCHEDULE_INTERVAL_ENV_NAME = (
     "DATA_SCIENCE_PEERSCOUT_RECOMMEND_SCHEDULE_INTERVAL"
+)
+
+DATA_SCIENCE_PEERSCOUT_RECOMMEND_QUEUE_ENV_NAME = (
+    "DATA_SCIENCE_PEERSCOUT_RECOMMEND_QUEUE"
 )
 
 
@@ -25,13 +31,21 @@ def get_schedule_interval() -> str:
     )
 
 
+def get_queue() -> str:
+    return os.getenv(
+        DATA_SCIENCE_PEERSCOUT_RECOMMEND_QUEUE_ENV_NAME,
+        DEFAULT_QUEUE
+    )
+
+
 # Note: need to save dag to a variable
 with create_dag(
         dag_id=DAG_ID,
         schedule_interval=get_schedule_interval()) as dag:
     _ = (
         create_run_notebook_operator(
-            notebook_filename='peerscout/peerscout-recommend-reviewing-editors.ipynb'
+            notebook_filename='peerscout/peerscout-recommend-reviewing-editors.ipynb',
+            queue=get_queue()
         )
         >> create_run_notebook_operator(
             notebook_filename='/'.join([

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -112,14 +112,14 @@ services:
     environment:
         - ALLOW_EMPTY_PASSWORD=yes
 
-  flower:
-    image: elifesciences/data-hub-ejp-xml-pipeline-dev
-    depends_on:
-        - redis
-    environment: *airflow-env
-    ports:
-        - "5555:5555"
-    command: celery flower
+  # flower:
+  #   image: elifesciences/data-science-airflow-dag:${IMAGE_TAG}
+  #   depends_on:
+  #       - redis
+  #   environment: *airflow-env
+  #   ports:
+  #       - "5555:5555"
+  #   command: celery flower
 
   peerscout-api:
     build:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,7 @@
 import logging
 from pathlib import Path
+from typing import Iterable
+from unittest.mock import patch
 
 import pytest
 from py._path.local import LocalPath
@@ -15,3 +17,10 @@ def setup_logging():
 def temp_dir(tmpdir: LocalPath):
     # convert to standard Path
     return Path(str(tmpdir))
+
+
+@pytest.fixture()
+def mock_env() -> Iterable[dict]:
+    env_dict: dict = {}
+    with patch('os.environ', env_dict):
+        yield env_dict

--- a/tests/dags/peerscout_recommend_reviewing_editors_test.py
+++ b/tests/dags/peerscout_recommend_reviewing_editors_test.py
@@ -1,0 +1,16 @@
+from airflow.models.baseoperator import DEFAULT_QUEUE
+
+from dags.peerscout_recommend_reviewing_editors import (
+    DATA_SCIENCE_PEERSCOUT_RECOMMEND_QUEUE_ENV_NAME,
+    get_queue
+)
+
+
+class TestGetQueue:
+    def test_should_return_default_queue_if_no_env_var_defined(self, mock_env: dict):
+        mock_env.clear()
+        assert get_queue() == DEFAULT_QUEUE
+
+    def test_should_return_selected_queue_from_evn_var(self, mock_env: dict):
+        mock_env[DATA_SCIENCE_PEERSCOUT_RECOMMEND_QUEUE_ENV_NAME] = 'queue1'
+        assert get_queue() == 'queue1'


### PR DESCRIPTION
part of https://github.com/elifesciences/data-hub-issues/issues/461
see also https://github.com/elifesciences/elife-flux-cluster/pull/2497

Optionally use kubernetes executor for the `Data_Science_PeerScout_Recommend_Reviewing_Editors` DAG, by being able to set the `queue` via the `DATA_SCIENCE_PEERSCOUT_RECOMMEND_QUEUE` env variable.