### PR TITLE
Fixed Airflow Pendulum dependency conflict

### DIFF
--- a/requirements.dag.txt
+++ b/requirements.dag.txt
@@ -1,6 +1,7 @@
 apache-airflow[crypto,celery,postgres,jdbc,ssh]==2.7.1
 apache-airflow-providers-amazon==7.2.1
 papermill==2.3.3
+pendulum==2.1.2
 click>=7.1.2
 ansiwrap==0.8.4
 zope.deprecation==4.4.0


### PR DESCRIPTION
The conflict was introduced with pendulum 3.

```text
venv/lib/python3.8/site-packages/airflow/settings.py:51: in <module>
    TIMEZONE = pendulum.tz.timezone("UTC")
E   TypeError: 'module' object is not callable
============================================ short test summary info =============================================
ERROR tests/dags/peerscout_recommend_reviewing_editors_test.py - TypeError: 'module' object is not callable
ERROR tests/utils/dags_test.py - TypeError: 'module' object is not callable
```