### PR TITLE
Fixed PeerScout API loading request containing empty array into BigQuery

### DIFF
--- a/data_science_pipeline/utils/json.py
+++ b/data_science_pipeline/utils/json.py
@@ -37,6 +37,11 @@ def get_recursive_json_compatible_value(value):
 
 
 def is_empty_value(value) -> bool:
+    try:
+        if not len(value):  # pylint: disable=use-implicit-booleaness-not-len
+            return True
+    except TypeError:
+        pass
     return (
         (value is None or np.isscalar(value))
         and (

--- a/peerscout_api/example-data/peerscout-api-request-with-empty-arrays.json
+++ b/peerscout_api/example-data/peerscout-api-request-with-empty-arrays.json
@@ -1,0 +1,19 @@
+{
+    "manuscript_id":"12345",
+    "tracking_number":"12345_ABC",
+    "revision_number":0,
+    "abstract":"<p>Lorem ipsum dolor sit amet, <i>consectetur adipiscing elit</i>, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>",
+    "title":"<b>Lorem Ipsum</b>",
+    "assigned_deputy_editors_id": [
+    ],
+    "author_suggestion":{
+      "include_reviewing_editors_id":[
+      ],
+      "exclude_reviewing_editors_id":[
+      ],
+      "include_senior_editors_id":[
+      ],
+      "exclude_senior_editors_id":[
+      ]
+    } 
+  }

--- a/tests/utils/json_test.py
+++ b/tests/utils/json_test.py
@@ -63,6 +63,12 @@ class TestRemoveKeyWithNullValue:
             'other': 'value'
         }) == {'key1': False, 'other': 'value'}
 
+    def test_should_remove_empty_list_from_dict(self):
+        assert remove_key_with_null_value({
+            'key1': [],
+            'other': 'value'
+        }) == {'other': 'value'}
+
     def test_should_remove_np_nan_from_dict(self):
         assert remove_key_with_null_value({
             'key1': np.nan,


### PR DESCRIPTION
part of https://github.com/elifesciences/data-hub-issues/issues/505

This fixes an error like this one:

> peerscout-api_1      | google.api_core.exceptions.BadRequest: 400 Error while reading data, error message: JSON table encountered too many errors, giving up. Rows: 1; errors: 1. Please look into the errors[] collection for more details.; Error while reading data, error message: JSON processing encountered too many errors, giving up. Rows: 1; errors: 1; max bad: 0; error percent: 0; Error while reading data, error message: JSON parsing error in row starting at position 0: No such field: provenance.recommendation_request.assigned_deputy_editors_id.