### PR TITLE
Fix default AIRFLOW_APPLICATIONS_DIRECTORY_PATH to match location of `notebooks` directory

### DIFF
--- a/Dockerfile.airflow
+++ b/Dockerfile.airflow
@@ -35,8 +35,7 @@ RUN if [ "${install_dev}" = "y" ]; then \
 
 ENV PATH /home/airflow/.local/bin:$PATH
 
-RUN mkdir $AIRFLOW_HOME/applications_file_directory
-ENV AIRFLOW_APPLICATIONS_DIRECTORY_PATH $AIRFLOW_HOME/applications_file_directory
+ENV AIRFLOW_APPLICATIONS_DIRECTORY_PATH $AIRFLOW_HOME
 
 COPY data_science_pipeline ./data_science_pipeline
 COPY notebooks ./notebooks


### PR DESCRIPTION
part of https://github.com/elifesciences/data-hub-issues/issues/965

see https://github.com/elifesciences/elife-flux-cluster/pull/3025