### PR TITLE
Avoid initialising logging at module level

### DIFF
--- a/data_science_pipeline/cli/peerscout_build_reviewing_editor_profiles.py
+++ b/data_science_pipeline/cli/peerscout_build_reviewing_editor_profiles.py
@@ -1,7 +1,7 @@
 import logging
 from data_science_pipeline.utils.notebook import run_notebook
 
-logging.basicConfig(level=logging.INFO)
+
 LOGGER = logging.getLogger(__name__)
 
 

--- a/data_science_pipeline/cli/peerscout_build_senior_editor_profiles.py
+++ b/data_science_pipeline/cli/peerscout_build_senior_editor_profiles.py
@@ -1,7 +1,7 @@
 import logging
 from data_science_pipeline.utils.notebook import run_notebook
 
-logging.basicConfig(level=logging.INFO)
+
 LOGGER = logging.getLogger(__name__)
 
 

--- a/data_science_pipeline/cli/peerscout_get_editor_pubmed_papers.py
+++ b/data_science_pipeline/cli/peerscout_get_editor_pubmed_papers.py
@@ -1,7 +1,7 @@
 import logging
 from data_science_pipeline.utils.notebook import run_notebook
 
-logging.basicConfig(level=logging.INFO)
+
 LOGGER = logging.getLogger(__name__)
 
 

--- a/data_science_pipeline/cli/peerscout_recommend_reviewing_editors.py
+++ b/data_science_pipeline/cli/peerscout_recommend_reviewing_editors.py
@@ -1,7 +1,7 @@
 import logging
 from data_science_pipeline.utils.notebook import run_notebook
 
-logging.basicConfig(level=logging.INFO)
+
 LOGGER = logging.getLogger(__name__)
 
 

--- a/data_science_pipeline/cli/peerscout_recommend_senior_editors.py
+++ b/data_science_pipeline/cli/peerscout_recommend_senior_editors.py
@@ -3,7 +3,7 @@ import argparse
 from typing import Optional
 from data_science_pipeline.utils.notebook import run_notebook
 
-logging.basicConfig(level=logging.INFO)
+
 LOGGER = logging.getLogger(__name__)
 
 


### PR DESCRIPTION
Not sure whether there was a reason to have it there. But it would be the wrong place to initialize logging.