### PR TITLE
PeerScout API: use SpaCy API

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,6 +59,7 @@ dev-install:
 	$(PIP) install --disable-pip-version-check -r requirements.jupyter.txt
 	$(PIP) install --disable-pip-version-check -r requirements.pipelines.txt
 	$(PIP) install --disable-pip-version-check -r requirements.prophet.txt
+	$(PIP) install --disable-pip-version-check -r requirements.api.txt
 	$(PIP) install --disable-pip-version-check -e . --no-deps
 
 

--- a/Makefile
+++ b/Makefile
@@ -121,6 +121,19 @@ dev-run-sample-notebook:
 		-p output_dataset $(OUTPUT_DATASET)
 
 
+dev-nlp-model-download:
+	$(PYTHON) -m spacy download en_core_web_sm
+
+
+dev-peerscout-api-start:
+	$(PYTHON) -m \
+		peerscout_api.main \
+		--reload \
+		--factory \
+		--host 127.0.0.1 \
+		--port 8000
+
+
 jupyter-build:
 	chmod a+w .
 	@if [ "$(NO_BUILD)" != "y" ]; then \

--- a/peerscout_api/main.py
+++ b/peerscout_api/main.py
@@ -26,6 +26,7 @@ from peerscout_api.recommend_editor import (
 
 DEFAULT_SPACY_LANGUAGE_MODEL_NAME = "en_core_web_sm"
 SPACY_LANGUAGE_MODEL_NAME_ENV_VALUE = "SPACY_LANGUAGE_MODEL_NAME"
+SPACY_KEYWORD_EXTRACTION_API_URL_ENV_VALUE = "SPACY_KEYWORD_EXTRACTION_API_URL"
 
 PEERSCOUT_API_TARGET_DATASET_ENV_NAME = "PEERSCOUT_API_TARGET_DATASET"
 DEFAULT_PEERSCOUT_API_TARGET_DATASET_VALUE = "ci"
@@ -122,6 +123,12 @@ def get_spacy_language_model_env() -> str:
     return os.getenv(
         SPACY_LANGUAGE_MODEL_NAME_ENV_VALUE,
         DEFAULT_SPACY_LANGUAGE_MODEL_NAME
+    )
+
+
+def get_spacy_keyword_extraction_api_url() -> str:
+    return os.getenv(
+        SPACY_KEYWORD_EXTRACTION_API_URL_ENV_VALUE
     )
 
 

--- a/peerscout_api/main.py
+++ b/peerscout_api/main.py
@@ -126,13 +126,16 @@ def get_spacy_language_model_env() -> str:
     )
 
 
-def get_spacy_keyword_extraction_api_url() -> str:
+def get_spacy_keyword_extraction_api_url() -> Optional[str]:
     return os.getenv(
         SPACY_KEYWORD_EXTRACTION_API_URL_ENV_VALUE
     )
 
 
 def get_keyword_extractor():
+    api_url = get_spacy_keyword_extraction_api_url()
+    if api_url:
+        raise NotImplementedError('api_url not yet implemented')
     return get_keyword_extractor_for_spacy_language_model(get_spacy_language_model_env())
 
 

--- a/peerscout_api/main.py
+++ b/peerscout_api/main.py
@@ -13,7 +13,8 @@ from flask import Flask, jsonify, request
 from werkzeug.exceptions import BadRequest
 
 from elife_data_hub_utils.keyword_extract.extract_keywords import (
-    get_keyword_extractor as get_keyword_extractor_for_spacy_language_model
+    get_keyword_extractor as get_keyword_extractor_for_spacy_language_model,
+    KeywordExtractor
 )
 
 from data_science_pipeline.utils.json import remove_key_with_null_value
@@ -132,10 +133,14 @@ def get_spacy_keyword_extraction_api_url() -> Optional[str]:
     )
 
 
-def get_keyword_extractor():
+class SpaCyApiKeywordExtractor():
+    pass
+
+
+def get_keyword_extractor() -> KeywordExtractor:
     api_url = get_spacy_keyword_extraction_api_url()
     if api_url:
-        raise NotImplementedError('api_url not yet implemented')
+        return SpaCyApiKeywordExtractor()
     return get_keyword_extractor_for_spacy_language_model(get_spacy_language_model_env())
 
 

--- a/peerscout_api/main.py
+++ b/peerscout_api/main.py
@@ -13,7 +13,7 @@ from flask import Flask, jsonify, request
 from werkzeug.exceptions import BadRequest
 
 from elife_data_hub_utils.keyword_extract.extract_keywords import (
-    get_keyword_extractor
+    get_keyword_extractor as get_keyword_extractor_for_spacy_language_model
 )
 
 from data_science_pipeline.utils.json import remove_key_with_null_value
@@ -130,6 +130,10 @@ def get_spacy_keyword_extraction_api_url() -> str:
     return os.getenv(
         SPACY_KEYWORD_EXTRACTION_API_URL_ENV_VALUE
     )
+
+
+def get_keyword_extractor():
+    return get_keyword_extractor_for_spacy_language_model(get_spacy_language_model_env())
 
 
 def get_model_path(deployment_env: str) -> str:
@@ -426,7 +430,7 @@ def write_peerscout_api_response_to_bq_in_a_thread(
 
 def create_app():
     app = Flask(__name__)
-    keyword_extractor = get_keyword_extractor(get_spacy_language_model_env())
+    keyword_extractor = get_keyword_extractor()
 
     MODEL_PATH = get_model_path(get_deployment_env())
     senior_editor_model_dict = load_model(MODEL_PATH, SENIOR_EDITOR_MODEL_NAME)

--- a/peerscout_api/main.py
+++ b/peerscout_api/main.py
@@ -1,3 +1,4 @@
+from dataclasses import dataclass
 from datetime import datetime, timezone
 import os
 import json
@@ -133,14 +134,15 @@ def get_spacy_keyword_extraction_api_url() -> Optional[str]:
     )
 
 
+@dataclass(frozen=True)
 class SpaCyApiKeywordExtractor():
-    pass
+    api_url: str
 
 
 def get_keyword_extractor() -> KeywordExtractor:
     api_url = get_spacy_keyword_extraction_api_url()
     if api_url:
-        return SpaCyApiKeywordExtractor()
+        return SpaCyApiKeywordExtractor(api_url=api_url)
     return get_keyword_extractor_for_spacy_language_model(get_spacy_language_model_env())
 
 

--- a/peerscout_api/main.py
+++ b/peerscout_api/main.py
@@ -1,4 +1,3 @@
-from dataclasses import dataclass
 from datetime import datetime, timezone
 import os
 import json
@@ -25,6 +24,7 @@ from peerscout_api.recommend_editor import (
     load_model,
     get_editor_recommendations_for_api
 )
+from peerscout_api.spacy_api_keyword_extractor import SpaCyApiKeywordExtractor
 
 DEFAULT_SPACY_LANGUAGE_MODEL_NAME = "en_core_web_sm"
 SPACY_LANGUAGE_MODEL_NAME_ENV_VALUE = "SPACY_LANGUAGE_MODEL_NAME"
@@ -132,11 +132,6 @@ def get_spacy_keyword_extraction_api_url() -> Optional[str]:
     return os.getenv(
         SPACY_KEYWORD_EXTRACTION_API_URL_ENV_VALUE
     )
-
-
-@dataclass(frozen=True)
-class SpaCyApiKeywordExtractor():
-    api_url: str
 
 
 def get_keyword_extractor() -> KeywordExtractor:

--- a/peerscout_api/recommend_editor.py
+++ b/peerscout_api/recommend_editor.py
@@ -93,7 +93,7 @@ def get_recommended_editors_with_probability(
 
 def get_editor_recommendations_for_api(
         model: PeerScoutModelProps,
-        extracted_keywords: list,
+        extracted_keywords: List[List[str]],
         top_n_editor: int):
 
     keyword_similarity = get_keyword_similarity(

--- a/peerscout_api/spacy_api_keyword_extractor.py
+++ b/peerscout_api/spacy_api_keyword_extractor.py
@@ -1,6 +1,26 @@
 from dataclasses import dataclass
+from typing import Iterable, List
+
+import requests
+
+from elife_data_hub_utils.keyword_extract.extract_keywords import (
+    KeywordExtractor
+)
+
+
+DEFAULT_TIMEOUT = 60
 
 
 @dataclass(frozen=True)
-class SpaCyApiKeywordExtractor():
+class SpaCyApiKeywordExtractor(KeywordExtractor):
     api_url: str
+
+    def iter_extract_keywords(
+        self,
+        text_list: Iterable[str]
+    ) -> Iterable[List[str]]:
+        requests.post(
+            url=self.api_url,
+            timeout=DEFAULT_TIMEOUT
+        )
+        return []

--- a/peerscout_api/spacy_api_keyword_extractor.py
+++ b/peerscout_api/spacy_api_keyword_extractor.py
@@ -25,8 +25,14 @@ def get_request_body(text_list: Iterable[str]) -> dict:
     }
 
 
-def get_batch_keywords_from_response(_response_json: dict) -> List[List[str]]:
-    return []
+def get_batch_keywords_from_response(response_json: dict) -> List[List[str]]:
+    return [
+        [
+            keyword_dict['keyword']
+            for keyword_dict in keyword_result['attributes']['keywords']
+        ]
+        for keyword_result in response_json['data']
+    ]
 
 
 @dataclass(frozen=True)
@@ -37,9 +43,9 @@ class SpaCyApiKeywordExtractor(KeywordExtractor):
         self,
         text_list: Iterable[str]
     ) -> Iterable[List[str]]:
-        requests.post(
+        response = requests.post(
             url=self.api_url,
             json=get_request_body(text_list),
             timeout=DEFAULT_TIMEOUT
         )
-        return []
+        return get_batch_keywords_from_response(response.json())

--- a/peerscout_api/spacy_api_keyword_extractor.py
+++ b/peerscout_api/spacy_api_keyword_extractor.py
@@ -48,4 +48,5 @@ class SpaCyApiKeywordExtractor(KeywordExtractor):
             json=get_request_body(text_list),
             timeout=DEFAULT_TIMEOUT
         )
+        response.raise_for_status()
         return get_batch_keywords_from_response(response.json())

--- a/peerscout_api/spacy_api_keyword_extractor.py
+++ b/peerscout_api/spacy_api_keyword_extractor.py
@@ -11,8 +11,18 @@ from elife_data_hub_utils.keyword_extract.extract_keywords import (
 DEFAULT_TIMEOUT = 60
 
 
-def get_request_body(_text_list: Iterable[str]) -> dict:
-    return {}
+def get_request_body(text_list: Iterable[str]) -> dict:
+    return {
+        'data': [
+            {
+                'type': 'extract-keyword-request',
+                'attributes': {
+                    'content': text
+                }
+            }
+            for text in text_list
+        ]
+    }
 
 
 @dataclass(frozen=True)

--- a/peerscout_api/spacy_api_keyword_extractor.py
+++ b/peerscout_api/spacy_api_keyword_extractor.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+import logging
 from typing import Iterable, List
 
 import requests
@@ -6,6 +7,9 @@ import requests
 from elife_data_hub_utils.keyword_extract.extract_keywords import (
     KeywordExtractor
 )
+
+
+LOGGER = logging.getLogger(__name__)
 
 
 DEFAULT_TIMEOUT = 60
@@ -43,6 +47,7 @@ class SpaCyApiKeywordExtractor(KeywordExtractor):
         self,
         text_list: Iterable[str]
     ) -> Iterable[List[str]]:
+        LOGGER.info('Extracting keywords using api_url: %r', self.api_url)
         response = requests.post(
             url=self.api_url,
             json=get_request_body(text_list),

--- a/peerscout_api/spacy_api_keyword_extractor.py
+++ b/peerscout_api/spacy_api_keyword_extractor.py
@@ -11,6 +11,10 @@ from elife_data_hub_utils.keyword_extract.extract_keywords import (
 DEFAULT_TIMEOUT = 60
 
 
+def get_request_body(_text_list: Iterable[str]) -> dict:
+    return {}
+
+
 @dataclass(frozen=True)
 class SpaCyApiKeywordExtractor(KeywordExtractor):
     api_url: str
@@ -21,6 +25,7 @@ class SpaCyApiKeywordExtractor(KeywordExtractor):
     ) -> Iterable[List[str]]:
         requests.post(
             url=self.api_url,
+            json=get_request_body(text_list),
             timeout=DEFAULT_TIMEOUT
         )
         return []

--- a/peerscout_api/spacy_api_keyword_extractor.py
+++ b/peerscout_api/spacy_api_keyword_extractor.py
@@ -25,6 +25,10 @@ def get_request_body(text_list: Iterable[str]) -> dict:
     }
 
 
+def get_batch_keywords_from_response(_response_json: dict) -> List[List[str]]:
+    return []
+
+
 @dataclass(frozen=True)
 class SpaCyApiKeywordExtractor(KeywordExtractor):
     api_url: str

--- a/peerscout_api/spacy_api_keyword_extractor.py
+++ b/peerscout_api/spacy_api_keyword_extractor.py
@@ -1,0 +1,6 @@
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class SpaCyApiKeywordExtractor():
+    api_url: str

--- a/tests_peerscout_api/unit_tests/conftest.py
+++ b/tests_peerscout_api/unit_tests/conftest.py
@@ -1,0 +1,11 @@
+from typing import Iterable
+from unittest.mock import patch
+
+import pytest
+
+
+@pytest.fixture()
+def mock_env() -> Iterable[dict]:
+    env_dict: dict = {}
+    with patch('os.environ', env_dict):
+        yield env_dict

--- a/tests_peerscout_api/unit_tests/main_test.py
+++ b/tests_peerscout_api/unit_tests/main_test.py
@@ -177,6 +177,11 @@ def _get_keyword_extractor_mock() -> Iterable[MagicMock]:
         yield mock
 
 
+@pytest.fixture(name='keyword_extractor_mock', autouse=True)
+def _keyword_extractor_mock(get_keyword_extractor_mock: MagicMock) -> MagicMock:
+    return get_keyword_extractor_mock.return_value
+
+
 @pytest.fixture(name='load_model_mock', autouse=True)
 def _load_model_mock() -> Iterable[MagicMock]:
     with patch.object(target_module, 'load_model') as mock:
@@ -241,6 +246,16 @@ class TestPeerscoutAPI:
     ):
         response = test_client.post('/api/peerscout', json=INPUT_DATA_WTIH_WEAK_ABSTRACT)
         assert _get_ok_json(response) == get_valid_no_recommendation_response()
+
+    def test_should_pass_abstract_to_keyword_extractor(
+        self,
+        test_client: FlaskClient,
+        keyword_extractor_mock: MagicMock
+    ):
+        test_client.post('/api/peerscout', json=INPUT_DATA_VALID)
+        keyword_extractor_mock.iter_extract_keywords(
+            text_list=[INPUT_DATA_VALID['abstract']]
+        )
 
     def test_should_respond_with_recomendation(
         self,

--- a/tests_peerscout_api/unit_tests/main_test.py
+++ b/tests_peerscout_api/unit_tests/main_test.py
@@ -253,7 +253,7 @@ class TestPeerscoutAPI:
         keyword_extractor_mock: MagicMock
     ):
         test_client.post('/api/peerscout', json=INPUT_DATA_VALID)
-        keyword_extractor_mock.iter_extract_keywords(
+        keyword_extractor_mock.iter_extract_keywords.assert_called_with(
             text_list=[INPUT_DATA_VALID['abstract']]
         )
 

--- a/tests_peerscout_api/unit_tests/main_test.py
+++ b/tests_peerscout_api/unit_tests/main_test.py
@@ -10,6 +10,7 @@ import pandas as pd
 
 from peerscout_api.main import (
     NOT_PROVIDED,
+    SPACY_KEYWORD_EXTRACTION_API_URL_ENV_VALUE,
     create_app,
     get_html_text_for_recommended_person,
     get_html_text_for_author_suggested_person,
@@ -20,6 +21,7 @@ from peerscout_api.main import (
     NO_RECOMMENDATION_HTML,
     EDITOR_TYPE_FOR_REVIEWING_EDITOR,
     EDITOR_TYPE_FOR_SENIOR_EDITOR,
+    get_spacy_keyword_extraction_api_url,
     pick_person_id_from_bq_result
 )
 
@@ -197,6 +199,16 @@ def _test_client() -> FlaskClient:
 def _get_ok_json(response):
     assert response.status_code == 200
     return response.json
+
+
+class TestGetSpacyKeywordExtractionApiUrl:
+    def test_should_return_none_if_not_configured(self, mock_env: dict):
+        assert SPACY_KEYWORD_EXTRACTION_API_URL_ENV_VALUE not in mock_env
+        assert not get_spacy_keyword_extraction_api_url()
+
+    def test_should_return_configured_url(self, mock_env: dict):
+        mock_env[SPACY_KEYWORD_EXTRACTION_API_URL_ENV_VALUE] = 'url_1'
+        assert get_spacy_keyword_extraction_api_url() == 'url_1'
 
 
 class TestPickPersonIdFromBqResult:

--- a/tests_peerscout_api/unit_tests/main_test.py
+++ b/tests_peerscout_api/unit_tests/main_test.py
@@ -251,13 +251,14 @@ class TestGetKeywordExtractor:
         get_keyword_extractor()
         get_keyword_extractor_for_spacy_language_model_mock.assert_called()
 
-    def test_should_return_spacy_api_keyword_extractor(
+    def test_should_return_spacy_api_keyword_extractor_with_api_url(
         self,
         mock_env: dict
     ):
         mock_env[SPACY_KEYWORD_EXTRACTION_API_URL_ENV_VALUE] = 'url_1'
         result = get_keyword_extractor()
         assert isinstance(result, SpaCyApiKeywordExtractor)
+        assert result.api_url == 'url_1'
 
 
 class TestPeerscoutAPI:

--- a/tests_peerscout_api/unit_tests/main_test.py
+++ b/tests_peerscout_api/unit_tests/main_test.py
@@ -1,6 +1,6 @@
 import logging
 from typing import Iterable
-from unittest.mock import patch, MagicMock
+from unittest.mock import ANY, patch, MagicMock
 
 from flask.testing import FlaskClient
 
@@ -255,6 +255,22 @@ class TestPeerscoutAPI:
         test_client.post('/api/peerscout', json=INPUT_DATA_VALID)
         keyword_extractor_mock.iter_extract_keywords.assert_called_with(
             text_list=[INPUT_DATA_VALID['abstract']]
+        )
+
+    def test_should_pass_extracted_keywords_into_get_editor_recommendations_for_api_func(
+        self,
+        test_client: FlaskClient,
+        keyword_extractor_mock: MagicMock,
+        get_editor_recommendations_for_api_mock: MagicMock
+    ):
+        keyword_extractor_mock.iter_extract_keywords.return_value = iter(
+            [['keyword_1', 'keyword_2']]
+        )
+        test_client.post('/api/peerscout', json=INPUT_DATA_VALID)
+        get_editor_recommendations_for_api_mock.assert_called_with(
+                ANY,
+                [['keyword_1', 'keyword_2']],
+                ANY
         )
 
     def test_should_respond_with_recomendation(

--- a/tests_peerscout_api/unit_tests/main_test.py
+++ b/tests_peerscout_api/unit_tests/main_test.py
@@ -11,7 +11,6 @@ import pandas as pd
 from peerscout_api.main import (
     NOT_PROVIDED,
     SPACY_KEYWORD_EXTRACTION_API_URL_ENV_VALUE,
-    SpaCyApiKeywordExtractor,
     create_app,
     get_html_text_for_recommended_person,
     get_html_text_for_author_suggested_person,
@@ -28,6 +27,7 @@ from peerscout_api.main import (
 )
 
 import peerscout_api.main as target_module
+from peerscout_api.spacy_api_keyword_extractor import SpaCyApiKeywordExtractor
 
 
 LOGGER = logging.getLogger(__name__)

--- a/tests_peerscout_api/unit_tests/main_test.py
+++ b/tests_peerscout_api/unit_tests/main_test.py
@@ -14,6 +14,7 @@ from peerscout_api.main import (
     create_app,
     get_html_text_for_recommended_person,
     get_html_text_for_author_suggested_person,
+    get_keyword_extractor,
     get_list_of_author_suggested_person_details_with_html_text,
     PersonProps,
     get_recommendation_html,
@@ -179,6 +180,12 @@ def _get_keyword_extractor_mock() -> Iterable[MagicMock]:
         yield mock
 
 
+@pytest.fixture(name='get_keyword_extractor_for_spacy_language_model_mock', autouse=True)
+def _get_keyword_extractor_for_spacy_language_model_mock() -> Iterable[MagicMock]:
+    with patch.object(target_module, 'get_keyword_extractor_for_spacy_language_model') as mock:
+        yield mock
+
+
 @pytest.fixture(name='keyword_extractor_mock', autouse=True)
 def _keyword_extractor_mock(get_keyword_extractor_mock: MagicMock) -> MagicMock:
     return get_keyword_extractor_mock.return_value
@@ -231,6 +238,15 @@ class TestPickPersonIdFromBqResult:
             person_ids_to_pick=[BQ_RESPONSE_DICT_2['person_id'], BQ_RESPONSE_DICT_1['person_id']]
         )
         assert actual_response == [BQ_RESPONSE_DICT_2, BQ_RESPONSE_DICT_1]
+
+
+class TestGetKeywordExtractor:
+    def test_should_call_get_keyword_extractor_for_spacy_language_model(
+        self,
+        get_keyword_extractor_for_spacy_language_model_mock: MagicMock
+    ):
+        get_keyword_extractor()
+        get_keyword_extractor_for_spacy_language_model_mock.assert_called()
 
 
 class TestPeerscoutAPI:

--- a/tests_peerscout_api/unit_tests/main_test.py
+++ b/tests_peerscout_api/unit_tests/main_test.py
@@ -243,10 +243,20 @@ class TestPickPersonIdFromBqResult:
 class TestGetKeywordExtractor:
     def test_should_call_get_keyword_extractor_for_spacy_language_model(
         self,
-        get_keyword_extractor_for_spacy_language_model_mock: MagicMock
+        get_keyword_extractor_for_spacy_language_model_mock: MagicMock,
+        mock_env: dict
     ):
+        assert SPACY_KEYWORD_EXTRACTION_API_URL_ENV_VALUE not in mock_env
         get_keyword_extractor()
         get_keyword_extractor_for_spacy_language_model_mock.assert_called()
+
+    def test_should_fail_with_api_url(
+        self,
+        mock_env: dict
+    ):
+        mock_env[SPACY_KEYWORD_EXTRACTION_API_URL_ENV_VALUE] = 'url_1'
+        with pytest.raises(NotImplementedError):
+            get_keyword_extractor()
 
 
 class TestPeerscoutAPI:

--- a/tests_peerscout_api/unit_tests/main_test.py
+++ b/tests_peerscout_api/unit_tests/main_test.py
@@ -11,6 +11,7 @@ import pandas as pd
 from peerscout_api.main import (
     NOT_PROVIDED,
     SPACY_KEYWORD_EXTRACTION_API_URL_ENV_VALUE,
+    SpaCyApiKeywordExtractor,
     create_app,
     get_html_text_for_recommended_person,
     get_html_text_for_author_suggested_person,
@@ -250,13 +251,13 @@ class TestGetKeywordExtractor:
         get_keyword_extractor()
         get_keyword_extractor_for_spacy_language_model_mock.assert_called()
 
-    def test_should_fail_with_api_url(
+    def test_should_return_spacy_api_keyword_extractor(
         self,
         mock_env: dict
     ):
         mock_env[SPACY_KEYWORD_EXTRACTION_API_URL_ENV_VALUE] = 'url_1'
-        with pytest.raises(NotImplementedError):
-            get_keyword_extractor()
+        result = get_keyword_extractor()
+        assert isinstance(result, SpaCyApiKeywordExtractor)
 
 
 class TestPeerscoutAPI:

--- a/tests_peerscout_api/unit_tests/spacy_api_keyword_extractor_test.py
+++ b/tests_peerscout_api/unit_tests/spacy_api_keyword_extractor_test.py
@@ -22,10 +22,22 @@ def _requests_post_mock(requests_mock: MagicMock) -> MagicMock:
     return requests_mock.post
 
 
+class TestGetRequestBody:
+    def test_should_return_keyword_request_body(self):
+        assert get_request_body(['text_1']) == {
+            'data': [{
+                'type': 'extract-keyword-request',
+                'attributes': {
+                    'content': 'text_1'
+                }
+            }]
+        }
+
+
 class TestSpaCyApiKeywordExtractor:
     def test_should_call_api(self, requests_post_mock: MagicMock):
         keyword_extractor = SpaCyApiKeywordExtractor(api_url=TEST_SPACY_API_URL_1)
-        keyword_extractor.iter_extract_keywords(text_list=['text1'])
+        keyword_extractor.iter_extract_keywords(text_list=['text_1'])
         requests_post_mock.assert_called_with(
             url=TEST_SPACY_API_URL_1,
             json=get_request_body(['text_1']),

--- a/tests_peerscout_api/unit_tests/spacy_api_keyword_extractor_test.py
+++ b/tests_peerscout_api/unit_tests/spacy_api_keyword_extractor_test.py
@@ -2,7 +2,10 @@
 
 from typing import Iterable
 from unittest.mock import ANY, MagicMock, patch
+
 import pytest
+
+import requests
 
 import peerscout_api.spacy_api_keyword_extractor as target_module
 from peerscout_api.spacy_api_keyword_extractor import (
@@ -84,3 +87,9 @@ class TestSpaCyApiKeywordExtractor:
         response_mock.json.return_value = SAMPLE_SPACY_API_RESPONSE_1
         extracted_keywords = list(keyword_extractor.iter_extract_keywords(text_list=['text_1']))
         assert extracted_keywords == get_batch_keywords_from_response(SAMPLE_SPACY_API_RESPONSE_1)
+
+    def test_should_raise_exception_for_error_response(self, response_mock: MagicMock):
+        keyword_extractor = SpaCyApiKeywordExtractor(api_url=TEST_SPACY_API_URL_1)
+        with pytest.raises(requests.exceptions.RequestException):
+            response_mock.raise_for_status.side_effect = requests.exceptions.RequestException
+            list(keyword_extractor.iter_extract_keywords(text_list=['text_1']))

--- a/tests_peerscout_api/unit_tests/spacy_api_keyword_extractor_test.py
+++ b/tests_peerscout_api/unit_tests/spacy_api_keyword_extractor_test.py
@@ -1,0 +1,32 @@
+
+
+from typing import Iterable
+from unittest.mock import ANY, MagicMock, patch
+import pytest
+
+import peerscout_api.spacy_api_keyword_extractor as target_module
+from peerscout_api.spacy_api_keyword_extractor import SpaCyApiKeywordExtractor
+
+
+TEST_SPACY_API_URL_1 = 'http://example/spacy-url-1'
+
+
+@pytest.fixture(name='requests_mock', autouse=True)
+def _requests_mock() -> Iterable[MagicMock]:
+    with patch.object(target_module, 'requests') as mock:
+        yield mock
+
+
+@pytest.fixture(name='requests_post_mock', autouse=True)
+def _requests_post_mock(requests_mock: MagicMock) -> MagicMock:
+    return requests_mock.post
+
+
+class TestSpaCyApiKeywordExtractor:
+    def test_should_call_api(self, requests_post_mock: MagicMock):
+        keyword_extractor = SpaCyApiKeywordExtractor(api_url=TEST_SPACY_API_URL_1)
+        keyword_extractor.iter_extract_keywords(text_list=['text1'])
+        requests_post_mock.assert_called_with(
+            url=TEST_SPACY_API_URL_1,
+            timeout=ANY
+        )

--- a/tests_peerscout_api/unit_tests/spacy_api_keyword_extractor_test.py
+++ b/tests_peerscout_api/unit_tests/spacy_api_keyword_extractor_test.py
@@ -5,7 +5,11 @@ from unittest.mock import ANY, MagicMock, patch
 import pytest
 
 import peerscout_api.spacy_api_keyword_extractor as target_module
-from peerscout_api.spacy_api_keyword_extractor import SpaCyApiKeywordExtractor, get_request_body
+from peerscout_api.spacy_api_keyword_extractor import (
+    SpaCyApiKeywordExtractor,
+    get_batch_keywords_from_response,
+    get_request_body
+)
 
 
 TEST_SPACY_API_URL_1 = 'http://example/spacy-url-1'
@@ -20,6 +24,11 @@ def _requests_mock() -> Iterable[MagicMock]:
 @pytest.fixture(name='requests_post_mock', autouse=True)
 def _requests_post_mock(requests_mock: MagicMock) -> MagicMock:
     return requests_mock.post
+
+
+@pytest.fixture(name='response_mock', autouse=True)
+def _response_mock(requests_post_mock: MagicMock) -> MagicMock:
+    return requests_post_mock.return_value
 
 
 class TestGetRequestBody:
@@ -43,3 +52,9 @@ class TestSpaCyApiKeywordExtractor:
             json=get_request_body(['text_1']),
             timeout=ANY
         )
+
+    def test_should_get_keywords_from_response(self, response_mock: MagicMock):
+        keyword_extractor = SpaCyApiKeywordExtractor(api_url=TEST_SPACY_API_URL_1)
+        response_mock.json.return_value = {}
+        extracted_keywords = list(keyword_extractor.iter_extract_keywords(text_list=['text_1']))
+        assert extracted_keywords == get_batch_keywords_from_response({})

--- a/tests_peerscout_api/unit_tests/spacy_api_keyword_extractor_test.py
+++ b/tests_peerscout_api/unit_tests/spacy_api_keyword_extractor_test.py
@@ -14,6 +14,26 @@ from peerscout_api.spacy_api_keyword_extractor import (
 
 TEST_SPACY_API_URL_1 = 'http://example/spacy-url-1'
 
+SAMPLE_SPACY_API_RESPONSE_1 = {
+    'data': [{
+        'type': 'extract-keyword-result',
+        'attributes': {
+            'keywords': [
+                {
+                    'keyword': 'biochemistry',
+                    'count': 1
+                },
+                {
+                    'keyword': 'neuroscience',
+                    'count': 1
+                }
+            ]
+        },
+    }]
+}
+
+SAMPLE_EXTRACTED_KEYWORDS_1 = [['biochemistry', 'neuroscience']]
+
 
 @pytest.fixture(name='requests_mock', autouse=True)
 def _requests_mock() -> Iterable[MagicMock]:
@@ -43,6 +63,12 @@ class TestGetRequestBody:
         }
 
 
+class TestGetBatchKeywordsFromResponse:
+    def test_should_return_keywords_from_api_response(self):
+        extracted_keywords = get_batch_keywords_from_response(SAMPLE_SPACY_API_RESPONSE_1)
+        assert extracted_keywords == SAMPLE_EXTRACTED_KEYWORDS_1
+
+
 class TestSpaCyApiKeywordExtractor:
     def test_should_call_api(self, requests_post_mock: MagicMock):
         keyword_extractor = SpaCyApiKeywordExtractor(api_url=TEST_SPACY_API_URL_1)
@@ -55,6 +81,6 @@ class TestSpaCyApiKeywordExtractor:
 
     def test_should_get_keywords_from_response(self, response_mock: MagicMock):
         keyword_extractor = SpaCyApiKeywordExtractor(api_url=TEST_SPACY_API_URL_1)
-        response_mock.json.return_value = {}
+        response_mock.json.return_value = SAMPLE_SPACY_API_RESPONSE_1
         extracted_keywords = list(keyword_extractor.iter_extract_keywords(text_list=['text_1']))
-        assert extracted_keywords == get_batch_keywords_from_response({})
+        assert extracted_keywords == get_batch_keywords_from_response(SAMPLE_SPACY_API_RESPONSE_1)

--- a/tests_peerscout_api/unit_tests/spacy_api_keyword_extractor_test.py
+++ b/tests_peerscout_api/unit_tests/spacy_api_keyword_extractor_test.py
@@ -5,7 +5,7 @@ from unittest.mock import ANY, MagicMock, patch
 import pytest
 
 import peerscout_api.spacy_api_keyword_extractor as target_module
-from peerscout_api.spacy_api_keyword_extractor import SpaCyApiKeywordExtractor
+from peerscout_api.spacy_api_keyword_extractor import SpaCyApiKeywordExtractor, get_request_body
 
 
 TEST_SPACY_API_URL_1 = 'http://example/spacy-url-1'
@@ -28,5 +28,6 @@ class TestSpaCyApiKeywordExtractor:
         keyword_extractor.iter_extract_keywords(text_list=['text1'])
         requests_post_mock.assert_called_with(
             url=TEST_SPACY_API_URL_1,
+            json=get_request_body(['text_1']),
             timeout=ANY
         )


### PR DESCRIPTION
part of https://github.com/elifesciences/data-hub-issues/issues/1047

When `SPACY_KEYWORD_EXTRACTION_API_URL` is configured, it will use that API instead of the SpaCy library.
`SPACY_KEYWORD_EXTRACTION_API_URL` should point to the URL of the batch endpoint.