### PR TITLE
Install most python dependencies together to make dependency conflicts visible when building Docker images in ci

### DIFF
--- a/Dockerfile.jupyter
+++ b/Dockerfile.jupyter
@@ -24,10 +24,15 @@ RUN pip install --disable-pip-version-check -r requirements.pipelines.txt \
   && jupyter nbextension enable --py widgetsnbextension
 
 COPY requirements.prophet.txt ./
-RUN pip install --disable-pip-version-check -r requirements.prophet.txt
+RUN pip install --disable-pip-version-check \
+    -r requirements.pipelines.txt \
+    -r requirements.prophet.txt
 
 COPY requirements.jupyter.ext.txt ./
-RUN pip install --disable-pip-version-check -r requirements.jupyter.ext.txt \
+RUN pip install --disable-pip-version-check \
+    -r requirements.pipelines.txt \
+    -r requirements.prophet.txt \
+    -r requirements.jupyter.ext.txt \
   && jupyter serverextension enable --py nbresuse --sys-prefix \
   && jupyter nbextension install --py nbresuse --sys-prefix \
   && jupyter nbextension enable --py nbresuse --sys-prefix
@@ -38,7 +43,11 @@ RUN pip install --disable-pip-version-check -e . --no-deps --user
 ARG install_dev=y
 COPY requirements.dev.txt ./
 RUN if [ "${install_dev}" = "y" ]; then \
-    pip install --disable-pip-version-check --user -r requirements.dev.txt; \
+    pip install --disable-pip-version-check --user \
+        -r requirements.pipelines.txt \
+        -r requirements.prophet.txt \
+        -r requirements.jupyter.ext.txt \
+        -r requirements.dev.txt; \
   fi
 
 COPY data_science_pipeline ./data_science_pipeline

--- a/Dockerfile.peerscout_api
+++ b/Dockerfile.peerscout_api
@@ -24,7 +24,9 @@ CMD ["python3", "-m", "peerscout_api.main"]
 FROM runtime AS dev
 
 COPY requirements.dev.txt ./
-RUN pip install --disable-pip-version-check -r requirements.dev.txt
+RUN pip install --disable-pip-version-check \
+    -r requirements.api.txt \
+    -r requirements.dev.txt
 
 COPY peerscout_api ./peerscout_api
 COPY data_science_pipeline ./data_science_pipeline

--- a/Dockerfile.pipelines
+++ b/Dockerfile.pipelines
@@ -18,14 +18,23 @@ COPY requirements.jupyter.txt ./
 RUN pip install --disable-pip-version-check -r requirements.jupyter.txt
 
 COPY requirements.pipelines.txt ./
-RUN pip install --disable-pip-version-check -r requirements.pipelines.txt
+RUN pip install --disable-pip-version-check \
+    -r requirements.jupyter.txt \
+    -r requirements.pipelines.txt
 
 COPY requirements.prophet.txt ./
-RUN pip install --disable-pip-version-check -r requirements.prophet.txt
+RUN pip install --disable-pip-version-check \
+    -r requirements.jupyter.txt \
+    -r requirements.pipelines.txt \
+    -r requirements.prophet.txt
 
 COPY requirements.dev.txt ./
 RUN if [ "${install_dev}" = "y" ]; then \
-    pip install --disable-pip-version-check --user -r requirements.dev.txt; \
+    pip install --disable-pip-version-check --user \
+        -r requirements.jupyter.txt \
+        -r requirements.pipelines.txt \
+        -r requirements.prophet.txt \
+        -r requirements.dev.txt; \
   fi
 
 COPY data_science_pipeline ./data_science_pipeline


### PR DESCRIPTION
Similar to what we had done for the virtual env.
We need to do it in ci too to keep dependency free of conflicts.